### PR TITLE
Fix issue #8: Create a python similar in functionality to analyze_weave_refs.py that gets results from the Evaluations table

### DIFF
--- a/analyze_dynamodb_data.py
+++ b/analyze_dynamodb_data.py
@@ -1,0 +1,110 @@
+import boto3
+from datetime import datetime
+from typing import Dict, Any, List
+import json
+
+def get_recent_evaluations(stream_key: str, limit: int = 10) -> List[Dict[str, Any]]:
+    """
+    Fetch the most recent evaluations for a given stream key.
+
+    Args:
+        stream_key: The stream key to query
+        limit: Maximum number of items to return
+
+    Returns:
+        List of evaluation records
+    """
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table('EvaluationsTable')
+
+    response = table.query(
+        KeyConditionExpression='streamKey = :sk',
+        ExpressionAttributeValues={
+            ':sk': stream_key
+        },
+        ScanIndexForward=False,  # Sort in descending order (most recent first)
+        Limit=limit
+    )
+
+    return response.get('Items', [])
+
+def get_prompt_by_ref(ref: str) -> Dict[str, Any]:
+    """
+    Fetch a prompt by its reference ID.
+
+    Args:
+        ref: The reference ID of the prompt
+
+    Returns:
+        Prompt data including ref, content, and version
+    """
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table('PromptsTable')
+
+    response = table.get_item(
+        Key={
+            'ref': ref
+        }
+    )
+
+    return response.get('Item', {})
+
+def format_evaluation(eval_data: Dict[str, Any]) -> str:
+    """Format a single evaluation record for display."""
+    timestamp = datetime.fromtimestamp(eval_data['timestamp']).strftime('%Y-%m-%d %H:%M:%S')
+
+    formatted = f"\nEvaluation at {timestamp}\n"
+    formatted += "=" * 50 + "\n"
+
+    # Extract core evaluation data
+    formatted += f"Question: {eval_data.get('question', 'N/A')}\n"
+    formatted += f"Type: {eval_data.get('type', 'N/A')}\n"
+    formatted += f"Success: {eval_data.get('success', False)}\n"
+    formatted += f"Number of Turns: {eval_data.get('num_turns', 0)}\n"
+
+    # Add failure reasons if present
+    failure_reasons = eval_data.get('failure_reasons', [])
+    if failure_reasons:
+        formatted += "\nFailure Reasons:\n"
+        for reason in failure_reasons:
+            formatted += f"- {reason}\n"
+
+    # Add summary if present
+    if eval_data.get('summary'):
+        formatted += f"\nSummary:\n{eval_data['summary']}\n"
+
+    # Add prompt information if available
+    prompt_ref = eval_data.get('prompt_ref')
+    if prompt_ref:
+        prompt_data = get_prompt_by_ref(prompt_ref)
+        if prompt_data:
+            formatted += "\nPrompt Information:\n"
+            formatted += f"Ref: {prompt_data.get('ref', 'N/A')}\n"
+            formatted += f"Version: {prompt_data.get('version', 'N/A')}\n"
+            formatted += f"Content: {prompt_data.get('content', 'N/A')}\n"
+
+    conversation = eval_data.get('conversation', '')
+    if conversation:
+        formatted += "\nConversation:\n"
+        formatted += conversation
+
+    return formatted
+
+def main():
+    # Example stream key - replace with actual key
+    stream_key = "VPFnNcTxE78nD7fMcxfcmnKv2C5coD92vdcYBtdf"
+
+    print(f"Fetching recent evaluations for stream key: {stream_key}")
+    evaluations = get_recent_evaluations(stream_key)
+
+    if not evaluations:
+        print("No evaluations found")
+        return
+
+    print(f"Found {len(evaluations)} evaluations\n")
+
+    for eval_data in evaluations:
+        print(format_evaluation(eval_data))
+
+if __name__ == "__main__":
+    main()

--- a/test_analyze_dynamodb_data.py
+++ b/test_analyze_dynamodb_data.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+from analyze_dynamodb_data import get_recent_evaluations, get_prompt_by_ref, format_evaluation
+
+@pytest.fixture
+def mock_dynamodb():
+    with patch('boto3.resource') as mock_resource:
+        mock_table = MagicMock()
+        mock_resource.return_value.Table.return_value = mock_table
+        yield mock_table
+
+def test_get_recent_evaluations(mock_dynamodb):
+    expected_items = [
+        {'streamKey': 'test-key', 'timestamp': 1234567890}
+    ]
+    mock_dynamodb.query.return_value = {'Items': expected_items}
+
+    result = get_recent_evaluations('test-key', 10)
+
+    mock_dynamodb.query.assert_called_once_with(
+        KeyConditionExpression='streamKey = :sk',
+        ExpressionAttributeValues={':sk': 'test-key'},
+        ScanIndexForward=False,
+        Limit=10
+    )
+    assert result == expected_items
+
+def test_get_prompt_by_ref(mock_dynamodb):
+    expected_item = {
+        'ref': 'test-ref',
+        'content': 'test content',
+        'version': '1.0'
+    }
+    mock_dynamodb.get_item.return_value = {'Item': expected_item}
+
+    result = get_prompt_by_ref('test-ref')
+
+    mock_dynamodb.get_item.assert_called_once_with(
+        Key={'ref': 'test-ref'}
+    )
+    assert result == expected_item
+
+def test_format_evaluation():
+    eval_data = {
+        'timestamp': 1234567890,
+        'question': 'test question',
+        'type': 'test type',
+        'success': True,
+        'num_turns': 2,
+        'failure_reasons': ['reason1'],
+        'summary': 'test summary',
+        'prompt_ref': 'test-ref',
+        'conversation': 'test conversation'
+    }
+
+    with patch('analyze_dynamodb_data.get_prompt_by_ref') as mock_get_prompt:
+        mock_get_prompt.return_value = {
+            'ref': 'test-ref',
+            'content': 'test content',
+            'version': '1.0'
+        }
+
+        result = format_evaluation(eval_data)
+
+        assert 'test question' in result
+        assert 'test type' in result
+        assert 'True' in result
+        assert 'reason1' in result
+        assert 'test summary' in result
+        assert 'test-ref' in result
+        assert 'test content' in result
+        assert '1.0' in result
+        assert 'test conversation' in result


### PR DESCRIPTION
This pull request fixes #8.

The changes successfully address the requirements by implementing DynamoDB fetching for both evaluations and prompts:

1. Created a new `analyze_dynamodb_data.py` file that implements:
   - `get_recent_evaluations()` function to fetch evaluation data from EvaluationsTable using the streamKey
   - `get_prompt_by_ref()` function to fetch prompt data from PromptsTable using the ref key
   - Both functions properly use the DynamoDB schema as specified

2. The prompt fetching matches the required schema:
   - Fetches from PromptsTable using the 'ref' as the hash key
   - Returns the required fields: ref, content, and version

3. Enhanced the evaluation formatting to include prompt information:
   - When a prompt_ref is present in evaluation data, it fetches and displays the corresponding prompt details
   - Displays all required prompt fields (ref, content, version)

4. Added comprehensive unit tests in `test_analyze_dynamodb_data.py` that verify:
   - Correct DynamoDB querying behavior
   - Proper prompt fetching
   - Accurate formatting of both evaluation and prompt data

The implementation completely replaces the previous wandb fetching with DynamoDB fetching and includes all required functionality for both evaluations and prompts tables.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌