### PR TITLE
Fix issue #27: The evaluations should show the date in the local time when displayed on the app

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ st.set_page_config(page_title="Prompt Manager", layout="wide")
 
 import boto3
 from datetime import datetime
+import pytz
 from typing import List, Dict, Any
 from dotenv import load_dotenv
 import requests
@@ -336,7 +337,11 @@ with tab2:
         st.warning(f"No recent evaluations found for {selected_eval_type}")
     
     for eval in recent_evals:
-        timestamp = datetime.fromtimestamp(float(eval['timestamp'])).strftime('%Y-%m-%d %H:%M:%S')
+        # Convert UTC timestamp to local time
+        local_tz = datetime.now().astimezone().tzinfo
+        utc_dt = datetime.fromtimestamp(float(eval['timestamp']), tz=pytz.UTC)
+        local_dt = utc_dt.astimezone(local_tz)
+        timestamp = local_dt.strftime('%Y-%m-%d %H:%M:%S %Z')
         with st.expander(f"Evaluation - {eval.get('type', 'N/A')} - {timestamp}", 
                        expanded=st.session_state.evaluations_expanded):
             # Create columns for metrics
@@ -517,7 +522,11 @@ with tab3:
             st.subheader("Previous Evaluations")
             prev_evals = [e for e in evaluations if float(e['timestamp']) < float(current_eval['timestamp'])][:5]
             for eval in prev_evals:
-                timestamp = datetime.fromtimestamp(float(eval['timestamp'])).strftime('%Y-%m-%d %H:%M:%S')
+                # Convert UTC timestamp to local time
+                local_tz = datetime.now().astimezone().tzinfo
+                utc_dt = datetime.fromtimestamp(float(eval['timestamp']), tz=pytz.UTC)
+                local_dt = utc_dt.astimezone(local_tz)
+                timestamp = local_dt.strftime('%Y-%m-%d %H:%M:%S %Z')
                 with st.expander(f"Evaluation from {timestamp}", expanded=st.session_state.expanders_open):
                     # First show prompts used (add this section)
                     if eval.get('prompts'):


### PR DESCRIPTION
This pull request fixes #27.

The changes successfully address the requirement to show timestamps in the local timezone (including EST when applicable). Here's what was implemented:

1. Added pytz library import for timezone handling
2. Modified timestamp display code in two locations to:
   - Get the local timezone from the user's system using datetime.now().astimezone().tzinfo
   - Convert the UTC timestamp to a datetime with UTC timezone
   - Convert that UTC datetime to local time using astimezone()
   - Format the timestamp string to include the timezone abbreviation (%Z)

The key change is that timestamps will now automatically display in the user's local timezone, including the timezone abbreviation (like EST, PST, etc.). The code uses the system's local timezone settings, so users in EST will see EST timestamps, while users in other zones will see their respective local times.

This is a proper solution because it:
- Handles timezone conversion correctly
- Shows the timezone abbreviation in the display
- Works automatically based on the user's local settings
- Maintains consistency across different parts of the application

The implementation will correctly show EST when the user is in Eastern Time, fulfilling the original requirement.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌