### PR TITLE
Fix issue #38: In teh prompts tab, it should allow to choose the type of okrs, insights, suggestions, design, code, and all, and prompt refs should be specified in arrays corresponding to each (hardcoded)

### DIFF
--- a/components/prompts_tab.py
+++ b/components/prompts_tab.py
@@ -8,7 +8,8 @@ from utils import (
     validate_prompt_parameters, 
     get_all_prompt_versions, 
     update_prompt,
-    log_debug
+    log_debug,
+    PROMPT_TYPES
 )
 
 def render_prompts_tab(prompts: List[Dict[str, Any]]):
@@ -19,12 +20,33 @@ def render_prompts_tab(prompts: List[Dict[str, Any]]):
     # Sidebar filters
     st.sidebar.header("Filters")
 
-    # Get unique refs for filtering
+    # Populate the "all" category with all unique refs
     all_refs = list(set([p["ref"] for p in prompts]))
-    selected_refs = st.sidebar.multiselect(
-        "Filter by refs",
-        options=all_refs,
+    PROMPT_TYPES["all"] = all_refs
+
+    # Prompt type selection
+    prompt_type_options = list(PROMPT_TYPES.keys())
+    selected_prompt_type = st.sidebar.selectbox(
+        "Select prompt type",
+        options=prompt_type_options,
+        index=0  # Default to "all"
     )
+
+    # Get refs for the selected prompt type
+    type_specific_refs = PROMPT_TYPES[selected_prompt_type]
+
+    # If "all" is selected, allow further filtering by specific refs
+    if selected_prompt_type == "all":
+        selected_refs = st.sidebar.multiselect(
+            "Filter by refs",
+            options=all_refs,
+        )
+    else:
+        # Show the refs for the selected type (informational only)
+        st.sidebar.write("Prompt refs for this type:")
+        for ref in type_specific_refs:
+            st.sidebar.write(f"- {ref}")
+        selected_refs = type_specific_refs
 
     # Search box
     search_term = st.sidebar.text_input("Search content").lower()
@@ -40,7 +62,7 @@ def render_prompts_tab(prompts: List[Dict[str, Any]]):
         )]
 
     # Display prompts
-    st.header("Prompts")
+    st.header(f"Prompts - {selected_prompt_type.capitalize()}")
     display_prompt_versions(filtered_prompts)
     st.sidebar.text(f"⏱️ Render prompts tab: {time.time() - start_time:.2f}s")
 

--- a/tests/test_prompt_types.py
+++ b/tests/test_prompt_types.py
@@ -1,0 +1,36 @@
+"""Test for prompt types functionality."""
+
+import unittest
+import sys
+import os
+
+# Add the parent directory to the path so we can import the utils module
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.prompt_utils import PROMPT_TYPES
+
+class TestPromptTypes(unittest.TestCase):
+    """Test the prompt types functionality."""
+
+    def test_prompt_types_structure(self):
+        """Test that the prompt types dictionary has the expected structure."""
+        # Check that all expected types are present
+        expected_types = ["all", "okr", "insights", "suggestion", "design", "code"]
+        for type_name in expected_types:
+            self.assertIn(type_name, PROMPT_TYPES, f"Expected type '{type_name}' not found in PROMPT_TYPES")
+
+        # Check that each type (except 'all') has a non-empty list of refs
+        for type_name, refs in PROMPT_TYPES.items():
+            if type_name != "all":  # 'all' can be empty initially
+                self.assertIsInstance(refs, list, f"Expected refs for '{type_name}' to be a list")
+                self.assertTrue(len(refs) > 0, f"Expected refs for '{type_name}' to be non-empty")
+
+                # Check that each ref follows the expected naming pattern
+                for ref in refs:
+                    self.assertTrue(
+                        ref.startswith(type_name) or ref.endswith(type_name),
+                        f"Expected ref '{ref}' to start or end with '{type_name}'"
+                    )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/prompt_utils.py
+++ b/utils/prompt_utils.py
@@ -19,6 +19,36 @@ from .validation_utils import (
     find_prompt_usage_in_code
 )
 
+# Define prompt types and their corresponding refs
+PROMPT_TYPES = {
+    "all": [],  # Will be populated with all refs
+    "okr": [
+        "okr_evaluation_prompt",
+        "okr_evaluation_questions",
+        "okr_system_prompt"
+    ],
+    "insights": [
+        "insights_evaluation_prompt",
+        "insights_evaluation_questions",
+        "insights_system_prompt"
+    ],
+    "suggestion": [
+        "suggestion_evaluation_prompt",
+        "suggestion_evaluation_questions",
+        "suggestion_system_prompt"
+    ],
+    "design": [
+        "design_evaluation_prompt",
+        "design_evaluation_questions",
+        "design_system_prompt"
+    ],
+    "code": [
+        "code_evaluation_prompt",
+        "code_evaluation_questions",
+        "code_system_prompt"
+    ]
+}
+
 # Global cache for prompt expected parameters
 _prompt_usage_cache = {}
 


### PR DESCRIPTION
This pull request fixes #38.

The issue has been successfully resolved. The PR implements a categorization system for prompts that allows users to filter prompts by their type (okr, insights, suggestion, design, code, or all). 

The key changes include:
1. Creation of a `PROMPT_TYPES` dictionary in `prompt_utils.py` that maps each prompt type to its relevant prompt references
2. Modification of the prompts tab UI to include a dropdown for selecting prompt types
3. Implementation of filtering logic that shows only the prompts relevant to the selected type
4. Dynamic UI updates that show the selected prompt type in the header and display the relevant refs

These changes directly address the issue description which requested that "we only see the prompts to update that are relevant to the task at hand" and that "the object should be specified in prompt utils." The implementation now allows users to focus on specific categories of prompts rather than seeing all prompts at once, making the interface more task-oriented and efficient.

The added test also verifies that the prompt types are correctly structured and that each type contains appropriate references, providing confidence in the implementation's correctness.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌